### PR TITLE
Update AWLServiceProxyHandler.ashx.cs

### DIFF
--- a/src/AWL.Citrix.Proxy/AWLServiceProxyHandler.ashx
+++ b/src/AWL.Citrix.Proxy/AWLServiceProxyHandler.ashx
@@ -1,1 +1,1 @@
-<%@ WebHandler Language="C#" CodeBehind="AWLCitrixClientHandler.ashx.cs" Class="AWL.Citrix.Proxy.AWLCitrixClientHandler" %>
+<%@ WebHandler Language="C#" CodeBehind="AWLServiceProxyHandler.ashx.cs" Class="AWL.Citrix.Proxy.AWLServiceProxyHandler" %>


### PR DESCRIPTION
The CodeBehind and Class atributes are referencing a class that does not exist. The name of the class that should be referening is "AWLServiceProxyHandler".